### PR TITLE
[TSK-35] chore,feat: queryDsl설정 추가, 하위 모듈 테스트 코드 수정

### DIFF
--- a/tp-back-app/application/tp-back-internal-app/build.gradle
+++ b/tp-back-app/application/tp-back-internal-app/build.gradle
@@ -5,10 +5,37 @@ plugins {
     id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
+/******* QueryDSL Start *******/
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+
+/******* QueryDSL End *******/
+
 /******* Start Spring Rest Docs *******/
 
 configurations {
     asciidoctorExt
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 ext {
@@ -59,6 +86,11 @@ dependencies {
     implementation project(':core:tp-base-core')
     testCompileOnly project(':core:tp-base-core')
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // https://mvnrepository.com/artifact/mysql/mysql-connector-java
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.28'
     implementation 'org.springframework.boot:spring-boot-starter-test'
@@ -67,6 +99,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.restdocs/spring-restdocs-mockmvc
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/config/querydsl/JpaConfig.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/config/querydsl/JpaConfig.java
@@ -1,0 +1,14 @@
+package com.trip.penguin.config.querydsl;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaAuditing // JPA Auditing 활성화
+@EntityScan(basePackages = "com.trip.penguin")
+@EnableJpaRepositories(basePackages = "com.trip.penguin")
+public class JpaConfig {
+
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/config/querydsl/QueryDslConfig.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.trip.penguin.config.querydsl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/controller/RoomRecController.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/controller/RoomRecController.java
@@ -1,0 +1,40 @@
+package com.trip.penguin.recommand.room.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.trip.penguin.constant.CommonConstant;
+import com.trip.penguin.recommand.room.repository.RoomCustomRepository;
+import com.trip.penguin.recommand.room.service.RoomRecServiceImpl;
+import com.trip.penguin.response.JsonResponse;
+
+@RestController
+@RequestMapping(value = "/rec/room")
+public class RoomRecController {
+
+	private RoomCustomRepository roomCustomRepository;
+
+	private RoomRecServiceImpl roomRecService;
+
+	@Autowired
+	public RoomRecController(RoomCustomRepository roomCustomRepository, RoomRecServiceImpl roomRecService) {
+
+		this.roomCustomRepository = roomCustomRepository;
+		this.roomRecService = roomRecService;
+	}
+
+	@GetMapping("/main")
+	public JsonResponse recommandRoomMain() {
+		roomRecService.getRoomRecMain();
+
+		roomCustomRepository.getMainRecRoom(PageRequest.of(1, 2));
+		return JsonResponse.builder()
+			.message(CommonConstant.SUCCESS.name())
+			.result(CommonConstant.SUCCESS)
+			.data("String")
+			.build();
+	}
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/dto/RoomRecDTO.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/dto/RoomRecDTO.java
@@ -1,0 +1,26 @@
+package com.trip.penguin.recommand.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoomRecDTO {
+
+	private String roomNm;
+
+	private String comNm;
+
+	private Long sellPrc;
+
+	private String couponYn;
+
+	private String thumbNail;
+
+	private Long rating;
+
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/repository/RoomCustomRepository.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/repository/RoomCustomRepository.java
@@ -1,0 +1,12 @@
+package com.trip.penguin.recommand.room.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.trip.penguin.room.domain.RoomMS;
+
+public interface RoomCustomRepository {
+
+	List<RoomMS> getMainRecRoom(Pageable pageable);
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/repository/RoomCustomRepositoryImpl.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/repository/RoomCustomRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.trip.penguin.recommand.room.repository;
+
+import static com.trip.penguin.room.domain.QRoomMS.*;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.trip.penguin.room.domain.RoomMS;
+
+@Repository
+public class RoomCustomRepositoryImpl implements RoomCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Autowired
+	public RoomCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public List<RoomMS> getMainRecRoom(Pageable pageable) {
+
+		List<RoomMS> fetch = jpaQueryFactory.selectFrom(roomMS).fetch();
+
+		return null;
+	}
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/repository/RoomRecRepository.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/repository/RoomRecRepository.java
@@ -1,0 +1,6 @@
+package com.trip.penguin.recommand.room.repository;
+
+import com.trip.penguin.room.repository.RoomMSRepository;
+
+public interface RoomRecRepository extends RoomMSRepository {
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/service/RoomRecService.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/service/RoomRecService.java
@@ -1,0 +1,4 @@
+package com.trip.penguin.recommand.room.service;
+
+public interface RoomRecService {
+}

--- a/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/service/RoomRecServiceImpl.java
+++ b/tp-back-app/application/tp-back-internal-app/src/main/java/com/trip/penguin/recommand/room/service/RoomRecServiceImpl.java
@@ -1,0 +1,38 @@
+package com.trip.penguin.recommand.room.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.trip.penguin.company.service.CompanyService;
+import com.trip.penguin.recommand.room.dto.RoomRecDTO;
+import com.trip.penguin.recommand.room.repository.RoomRecRepository;
+import com.trip.penguin.room.domain.RoomMS;
+import com.trip.penguin.room.service.RoomService;
+
+@Service
+public class RoomRecServiceImpl {
+
+	private final RoomRecRepository roomRecRepository;
+
+	private final RoomService roomService;
+
+	private final CompanyService companyService;
+
+	@Autowired
+	public RoomRecServiceImpl(RoomRecRepository roomRecRepository, RoomService roomService,
+		CompanyService companyService) {
+		this.companyService = companyService;
+		this.roomRecRepository = roomRecRepository;
+		this.roomService = roomService;
+	}
+
+	public List<RoomRecDTO> getRoomRecMain() {
+		RoomMS roomMS = new RoomMS();
+		roomMS.setId(0L);
+
+		List<RoomMS> roomPicListByRoomId = roomService.getRoomPicListByRoomId(roomMS);
+		return null;
+	}
+}

--- a/tp-back-app/application/tp-back-internal-app/src/test/java/com/trip/penguin/recommand/RecRoomDataTest.java
+++ b/tp-back-app/application/tp-back-internal-app/src/test/java/com/trip/penguin/recommand/RecRoomDataTest.java
@@ -1,0 +1,37 @@
+package com.trip.penguin.recommand;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.trip.penguin.recommand.room.repository.RoomCustomRepository;
+
+@ActiveProfiles("local")
+// @DataJpaTest가 빈설정에서 오류 발생
+// 해결이 안되서 일단 SpringBootTest로 진행
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class RecRoomDataTest {
+
+	private RoomCustomRepository roomCustomRepository;
+
+	@Autowired
+	public RecRoomDataTest(RoomCustomRepository roomCustomRepository) {
+		this.roomCustomRepository = roomCustomRepository;
+	}
+
+	@Test
+	@DisplayName("리뷰 생성, 조회 테스트")
+	void createRoomTest() {
+
+		Pageable pageable = PageRequest.of(1, 2);
+		roomCustomRepository.getMainRecRoom(pageable);
+
+	}
+
+}

--- a/tp-back-app/application/tp-back-internal-app/src/test/java/com/trip/penguin/recommand/RecRoomWebTest.java
+++ b/tp-back-app/application/tp-back-internal-app/src/test/java/com/trip/penguin/recommand/RecRoomWebTest.java
@@ -6,19 +6,30 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
 import com.trip.penguin.TpBackInternalApp;
 import com.trip.penguin.config.AbstractRestDocsTests;
-import com.trip.penguin.controller.TestController;
+import com.trip.penguin.recommand.room.controller.RoomRecController;
+import com.trip.penguin.recommand.room.repository.RoomCustomRepository;
+import com.trip.penguin.recommand.room.service.RoomRecServiceImpl;
 
-@WebMvcTest(TestController.class)
+@ActiveProfiles("local")
+@WebMvcTest(RoomRecController.class)
 @ContextConfiguration(classes = TpBackInternalApp.class)
-public class RecommandRoom extends AbstractRestDocsTests {
+public class RecRoomWebTest extends AbstractRestDocsTests {
+
+	@MockBean
+	private RoomCustomRepository roomCustomRepository;
+
+	@MockBean
+	private RoomRecServiceImpl roomRecService;
 
 	@Test
 	public void sample() throws Exception {
-		mockMvc.perform(get("/"))
+		mockMvc.perform(get("/rec/room/main"))
 			.andExpect(status().isOk())
 			.andDo(document("sample"));
 	}

--- a/tp-back-app/build.gradle
+++ b/tp-back-app/build.gradle
@@ -46,15 +46,7 @@ project('application:tp-batch-app') {
 
 
 project('domain:tp-rdb-domain') {
-    dependencies {
-        implementation project(':core:tp-base-core')
-        testCompileOnly project(':core:tp-base-core')
 
-        // https://mvnrepository.com/artifact/mysql/mysql-connector-java
-        implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.28'
-        implementation 'org.springframework.boot:spring-boot-starter-test'
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    }
 }
 
 project('system:tp-web-system') {

--- a/tp-back-app/domain/tp-rdb-domain/build.gradle
+++ b/tp-back-app/domain/tp-rdb-domain/build.gradle
@@ -1,3 +1,51 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.0.12'
+    id 'io.spring.dependency-management' version '1.1.3'
+    // queryDsl 플러그인 사용시 gradle 빌드시 에러 발생
+//    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+}
+
+/******* QueryDSL Start *******/
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+
+/******* QueryDSL End *******/
+
+dependencies {
+    implementation project(':core:tp-base-core')
+    testCompileOnly project(':core:tp-base-core')
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // https://mvnrepository.com/artifact/mysql/mysql-connector-java
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.28'
+    implementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+}
+
+
 bootJar {
     enabled = false
 }

--- a/tp-back-app/domain/tp-rdb-domain/src/main/java/com/trip/penguin/TpRdbDomain.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/main/java/com/trip/penguin/TpRdbDomain.java
@@ -1,6 +1,7 @@
 package com.trip.penguin;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class TpRdbDomain {
 }

--- a/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/config/JpaDataConfig.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/config/JpaDataConfig.java
@@ -1,0 +1,21 @@
+package com.trip.penguin.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.trip.penguin.TpRdbDomainTest;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("local")
+@ContextConfiguration(classes = TpRdbDomainTest.class)
+@EnableJpaRepositories(basePackages = {"com.trip.penguin"})
+@EntityScan(basePackages = "com.trip.penguin")
+@ComponentScan(value = "com.trip.penguin")
+public @interface JpaDataConfig {
+}

--- a/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/follow/FollowCRUDTest.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/follow/FollowCRUDTest.java
@@ -12,9 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ActiveProfiles;
 
+import com.trip.penguin.config.JpaDataConfig;
 import com.trip.penguin.follow.domain.FollowMS;
 import com.trip.penguin.follow.service.FollowService;
 import com.trip.penguin.user.domain.UserMS;
@@ -22,9 +21,8 @@ import com.trip.penguin.user.service.UserService;
 
 import jakarta.persistence.EntityManager;
 
-@ActiveProfiles("local")
+@JpaDataConfig
 @DataJpaTest(properties = "classpath:application.yaml")
-@ComponentScan(value = "com.trip.penguin")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class FollowCRUDTest {
 

--- a/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/review/ReviewCRUDTest.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/review/ReviewCRUDTest.java
@@ -12,13 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.trip.penguin.booking.domain.BookingMS;
 import com.trip.penguin.booking.service.BookingMsService;
 import com.trip.penguin.company.domain.CompanyMS;
 import com.trip.penguin.company.service.CompanyService;
+import com.trip.penguin.config.JpaDataConfig;
 import com.trip.penguin.constant.CommonConstant;
 import com.trip.penguin.review.domain.ReviewMS;
 import com.trip.penguin.review.service.ReviewService;
@@ -29,9 +28,8 @@ import com.trip.penguin.user.service.UserService;
 
 import jakarta.persistence.EntityManager;
 
-@ActiveProfiles("local")
+@JpaDataConfig
 @DataJpaTest(properties = "classpath:application.yaml")
-@ComponentScan(value = "com.trip.penguin")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class ReviewCRUDTest {
 

--- a/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/room/RoomCRUDTest.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/room/RoomCRUDTest.java
@@ -11,20 +11,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.trip.penguin.company.domain.CompanyMS;
 import com.trip.penguin.company.service.CompanyService;
+import com.trip.penguin.config.JpaDataConfig;
 import com.trip.penguin.constant.CommonConstant;
 import com.trip.penguin.room.domain.RoomMS;
 import com.trip.penguin.room.service.RoomService;
 
 import jakarta.persistence.EntityManager;
 
-@ActiveProfiles("local")
+@JpaDataConfig
 @DataJpaTest(properties = "classpath:application.yaml")
-@ComponentScan(value = "com.trip.penguin")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class RoomCRUDTest {
 

--- a/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/room/RoomImageCRUDTest.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/room/RoomImageCRUDTest.java
@@ -12,11 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ActiveProfiles;
 
 import com.trip.penguin.company.domain.CompanyMS;
 import com.trip.penguin.company.service.CompanyService;
+import com.trip.penguin.config.JpaDataConfig;
 import com.trip.penguin.constant.CommonConstant;
 import com.trip.penguin.room.domain.RoomMS;
 import com.trip.penguin.room.domain.RoomPicMS;
@@ -25,9 +24,8 @@ import com.trip.penguin.room.service.RoomService;
 
 import jakarta.persistence.EntityManager;
 
-@ActiveProfiles("local")
+@JpaDataConfig
 @DataJpaTest(properties = "classpath:application.yaml")
-@ComponentScan(value = "com.trip.penguin")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class RoomImageCRUDTest {
 

--- a/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/user/UserCRUDTest.java
+++ b/tp-back-app/domain/tp-rdb-domain/src/test/java/com/trip/penguin/user/UserCRUDTest.java
@@ -8,18 +8,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.test.context.ActiveProfiles;
 
+import com.trip.penguin.config.JpaDataConfig;
 import com.trip.penguin.follow.service.FollowService;
 import com.trip.penguin.user.domain.UserMS;
 import com.trip.penguin.user.service.UserService;
 
 import jakarta.persistence.EntityManager;
 
-@ActiveProfiles("local")
+@JpaDataConfig
 @DataJpaTest(properties = "classpath:application.yaml")
-@ComponentScan(value = "com.trip.penguin")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class UserCRUDTest {
 

--- a/tp-back-app/system/tp-web-system/src/main/java/com/trip/penguin/TpWebSystem.java
+++ b/tp-back-app/system/tp-web-system/src/main/java/com/trip/penguin/TpWebSystem.java
@@ -1,8 +1,7 @@
 package com.trip.penguin;
 
+import org.springframework.context.annotation.Configuration;
 
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-@SpringBootApplication
+@Configuration
 public class TpWebSystem {
 }


### PR DESCRIPTION
- queryDsl 의존성 설정 추가
- 하위 모듈에 SpringApplication제거 후 하위 모듈 메인 클래스 Configuration으로 변경 (application레벨에서 테스트 작성시 하위 SpringApplication multiple로 잡혀 오류 발생)
- JpaConfig클래스 추가 하위 jpa스캔 범위 설정